### PR TITLE
Print out player hand before each choice.

### DIFF
--- a/brains/human.py
+++ b/brains/human.py
@@ -47,14 +47,16 @@ def _random_witty_remark(card):
     ]).format(card=card.name)
 
 
+CARD_ABBREVIATIONS = ['Mus', 'Pes', 'Spy', 'Asn', 'Amb', 'Wiz', 'Gen', 'Pri']
+
+
 def _print_hand(cards):
-    numeric_cards = sorted(card.value for card in cards)
-    for card in numeric_cards:
-        print ' {}  '.format(card),
-    print
-    for card in numeric_cards:
-        print '{} '.format(card.get_short_name()),
-    print
+    try:
+        numeric_cards = sorted(card.value for card in cards)
+        print ' '.join(' {} '.format(card) for card in numeric_cards)
+        print ' '.join(CARD_ABBREVIATIONS[card] for card in numeric_cards)
+    except IndexError:
+        pass
 
 
 def input_fight():

--- a/components/cards.py
+++ b/components/cards.py
@@ -17,13 +17,6 @@ class Card(Enum):
             item for item in cls if item.value is n
         ).next()
 
-    def get_short_name(self):
-        short_card_names = ['Mus', 'Pes', 'Spy', 'Asn', 'Amb', 'Wiz', 'Gen', 'Pri']
-        try:
-            return short_card_names[self.value]
-        except IndexError:
-            return '???'
-
 
 def initial_hand():
     # In a vanilla game, players will start with one of each card


### PR DESCRIPTION
It bugged me that I couldn't see my hand before each turn. So I made it do that.

Two other minor changes:
- Print a blank line after a game ends. I had a hard time realizing a game was over, since another one starts up right away.
- Use raw_input instead of input. Safer, and can't cause a syntax error. Let me know if I am missing some good reason to use input.
